### PR TITLE
Gradle Update / Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,10 @@
 A mod meant to dump recipes from NEI for use outside of the running game
 
 A fork of [Nei Data Dump](https://github.com/NamesAreAPain/NEIDataDump)
+
+
+## Usage
+
+/neidatadump [i]tems [r]ecipes [o]redict [a]spects\nEither space seprated words/letters or a single term -iroa
+
+exports into .minecraft folder as a file called (recipes | items | oredict | aspects).json

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.github.GTNewHorizons:ForgeGradle:1.2.5'
+        classpath 'com.github.GTNewHorizons:ForgeGradle:1.2.7'
     }
 }
 


### PR DESCRIPTION
Readme updated to gives steps on how to export and what to look for after you export.

Fixed Gradle to latest version(1.2.7) since 1.2.5 no longer exists.